### PR TITLE
Remove region from aws_s3_bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ and currently maintained by the [INF](https://github.com/orgs/ryte/teams/inf).
 
 ## Changelog
 
+- 0.4.3 - Remove `region` from `aws_s3_bucket`
 - 0.4.2 - Add variable `environment` instead of reading from tags
 - 0.4.1 - Fix typo in cross-allow module
 - 0.4.0 - Upgrade to terraform 0.12.x

--- a/cross-allow/README.md
+++ b/cross-allow/README.md
@@ -36,7 +36,7 @@ and currently maintained by the [INF](https://github.com/orgs/ryte/teams/inf).
 
 ```hcl
 module "fancy_cat" {
-  source         = "github.com/ryte/INF-tf-s3//cross-allow?ref=v0.4.2"
+  source         = "github.com/ryte/INF-tf-s3//cross-allow?ref=v0.4.3"
   name           = "fancy-cat"
   tags           = local.common_tags
   environment    = var.environment

--- a/cross-allow/main.tf
+++ b/cross-allow/main.tf
@@ -1,11 +1,7 @@
-data "aws_region" "current" {
-}
-
 resource "aws_s3_bucket" "s3" {
   acl    = "private"
   bucket = local.name
   tags   = merge(local.tags, {type = "data"})
-  region = data.aws_region.current.name
 
   versioning {
     enabled = var.versioning_enabled

--- a/state/README.md
+++ b/state/README.md
@@ -30,7 +30,7 @@ and currently maintained by the [INF](https://github.com/orgs/ryte/teams/inf).
 
 ```hcl
 module "state" {
-  source      = "github.com/ryte/INF-tf-s3//state?ref=v0.4.2"
+  source      = "github.com/ryte/INF-tf-s3//state?ref=v0.4.3"
   name        = var.remote_state_bucket
   tags        = local.common_tags
   environment = var.environment

--- a/state/main.tf
+++ b/state/main.tf
@@ -1,11 +1,7 @@
-data "aws_region" "current" {
-}
-
 resource "aws_s3_bucket" "bucket" {
   acl    = "private"
   bucket = var.name
   tags   = merge(local.tags, {type = "data"})
-  region = data.aws_region.current.name
 
   versioning {
     enabled = var.versioning_enabled

--- a/website/README.md
+++ b/website/README.md
@@ -57,7 +57,7 @@ and currently maintained by the [INF](https://github.com/orgs/ryte/teams/inf).
 
 ```hcl
 module "website" {
-  source      = "github.com/ryte/INF-tf-s3//website?ref=v0.4.2"
+  source      = "github.com/ryte/INF-tf-s3//website?ref=v0.4.3"
   name        = "fancy_name"
   tags        = local.common_tags
   environment = var.environment

--- a/website/main.tf
+++ b/website/main.tf
@@ -1,11 +1,7 @@
-data "aws_region" "current" {
-}
-
 resource "aws_s3_bucket" "this" {
   acl    = "public-read"
   bucket = var.name
   tags   = merge(local.tags, {type = "data"})
-  region = data.aws_region.current.name
 
   versioning {
     enabled    = var.versioning_enabled


### PR DESCRIPTION
```
Error: Value for unconfigurable attribute

  on main.tf line 8, in resource "aws_s3_bucket" "s3":
   8:   region = data.aws_region.current.name

Can't configure a value for "region": its value will be decided automatically
based on the result of applying this configuration.
```